### PR TITLE
Bugfix/duplicate search buttons disabled while searching

### DIFF
--- a/src/SorterExpress/Classes/FFWorker.cs
+++ b/src/SorterExpress/Classes/FFWorker.cs
@@ -66,7 +66,7 @@ namespace SorterExpress.Classes
 
         private static string CreateFfmpegThumbnailArgs(string input, string output, int size)
         {
-            // -ss (Screenshot this far into the video (1 second ftb).
+            // -ss (Screenshot this far into the video (2 seconds ftb).
             // -y (Overwrite output if it already exists).
             // -vframes: 1 (Output 1 frame).
             // -vf (??).

--- a/src/SorterExpress/Controllers/DuplicatesFormController.cs
+++ b/src/SorterExpress/Controllers/DuplicatesFormController.cs
@@ -66,7 +66,6 @@ namespace SorterExpress.Controllers
         {
             form = duplicatesForm;
             model = new DuplicatesFormModel();
-            model.Duplicates = new SortableBindingList<Duplicate>();
 
             printsWorker = new BackgroundWorker
             {
@@ -498,10 +497,10 @@ namespace SorterExpress.Controllers
 
                     if (isMatch)
                     {
-                        form.Invoke((MethodInvoker)delegate ()
+                        form.Invoke(delegate ()
                         {
                             lock (duplicatesLock)
-                            { 
+                            {
                                 model.Duplicates.Add(new Duplicate(print, prints[i]));
                             }
                         });

--- a/src/SorterExpress/Forms/DuplicatesForm.Designer.cs
+++ b/src/SorterExpress/Forms/DuplicatesForm.Designer.cs
@@ -109,7 +109,7 @@ namespace SorterExpress.Forms
             this.keepRightButton.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.keepRightButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.duplicatesFormModelBindingSource, "StateSorting", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.keepRightButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.duplicatesFormModelBindingSource, "StateViewingDuplicates", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.keepRightButton.Location = new System.Drawing.Point(345, 0);
             this.keepRightButton.Margin = new System.Windows.Forms.Padding(2, 0, 0, 0);
             this.keepRightButton.MaximumSize = new System.Drawing.Size(0, 23);
@@ -129,7 +129,7 @@ namespace SorterExpress.Forms
             this.keepLeftButton.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.keepLeftButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.duplicatesFormModelBindingSource, "StateSorting", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.keepLeftButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.duplicatesFormModelBindingSource, "StateViewingDuplicates", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.keepLeftButton.Location = new System.Drawing.Point(0, 0);
             this.keepLeftButton.Margin = new System.Windows.Forms.Padding(0, 0, 2, 0);
             this.keepLeftButton.MaximumSize = new System.Drawing.Size(0, 23);
@@ -144,7 +144,7 @@ namespace SorterExpress.Forms
             // 
             this.keepBothButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.keepBothButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.duplicatesFormModelBindingSource, "StateSorting", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.keepBothButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.duplicatesFormModelBindingSource, "StateViewingDuplicates", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.keepBothButton.Location = new System.Drawing.Point(198, 353);
             this.keepBothButton.Name = "keepBothButton";
             this.keepBothButton.Size = new System.Drawing.Size(686, 23);
@@ -529,7 +529,7 @@ namespace SorterExpress.Forms
             // optionsLeftButton
             // 
             this.optionsLeftButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.optionsLeftButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.duplicatesFormModelBindingSource, "StateSorting", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.optionsLeftButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.duplicatesFormModelBindingSource, "StateViewingDuplicates", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.optionsLeftButton.Image = global::SorterExpress.Properties.Resources.down;
             this.optionsLeftButton.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.optionsLeftButton.Location = new System.Drawing.Point(0, 212);
@@ -545,7 +545,7 @@ namespace SorterExpress.Forms
             // optionsRightButton
             // 
             this.optionsRightButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.optionsRightButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.duplicatesFormModelBindingSource, "StateSorting", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.optionsRightButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.duplicatesFormModelBindingSource, "StateViewingDuplicates", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.optionsRightButton.Image = global::SorterExpress.Properties.Resources.down;
             this.optionsRightButton.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.optionsRightButton.Location = new System.Drawing.Point(9, 212);
@@ -716,7 +716,7 @@ namespace SorterExpress.Forms
             // 
             this.keepNeitherButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.keepNeitherButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.duplicatesFormModelBindingSource, "StateSorting", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.keepNeitherButton.DataBindings.Add(new System.Windows.Forms.Binding("Enabled", this.duplicatesFormModelBindingSource, "StateViewingDuplicates", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.keepNeitherButton.Location = new System.Drawing.Point(198, 377);
             this.keepNeitherButton.Name = "keepNeitherButton";
             this.keepNeitherButton.Size = new System.Drawing.Size(686, 23);

--- a/src/SorterExpress/Forms/MassTagForm.cs
+++ b/src/SorterExpress/Forms/MassTagForm.cs
@@ -33,7 +33,7 @@ namespace SorterExpress.Forms
 
             enabledTags = new List<string>();
 
-            tags = Settings.Default.Tags?.ToList() ?? new List<string>();
+            tags = Settings.Default.Tags.ToList() ?? new List<string>();
 
             if (Settings.Default.DisplayAllTags)
             { 

--- a/src/SorterExpress/Forms/MassTagForm.cs
+++ b/src/SorterExpress/Forms/MassTagForm.cs
@@ -33,7 +33,7 @@ namespace SorterExpress.Forms
 
             enabledTags = new List<string>();
 
-            tags = Settings.Default.Tags.ToList() ?? new List<string>();
+            tags = Settings.Default.Tags?.ToList() ?? new List<string>();
 
             if (Settings.Default.DisplayAllTags)
             { 

--- a/src/SorterExpress/Models/DuplicatesFormModel.cs
+++ b/src/SorterExpress/Models/DuplicatesFormModel.cs
@@ -113,7 +113,7 @@ namespace SorterExpress.Models
         private bool onlyMatchSameFileTypes = Settings.Default.DuplicateSearch.OnlyMatchSameFileTypes;
         private bool cropLeftAndRight = Settings.Default.DuplicateSearch.CropLeftRightSides;
         private bool cropTopAndBottom = Settings.Default.DuplicateSearch.CropTopBottomSides;
-        private int threadCount = Settings.Default.DuplicateSearch.SearchThreadCount == 0 ? Environment.ProcessorCount : Settings.Default.DuplicateSearch.SearchThreadCount;
+        private int threadCount = Settings.Default.DuplicateSearch.SearchThreadCount < 1 ? Environment.ProcessorCount : Settings.Default.DuplicateSearch.SearchThreadCount;
         private int similarity = Settings.Default.DuplicateSearch.SearchSimilarityPercentage;
         private bool mergeFileTags = Settings.Default.DuplicateSearch.MergeFileTags;
         private bool onlyKeepTagsThatAreInLibrary = Settings.Default.DuplicateSearch.OnlyKeepTagsInLibrary;

--- a/src/SorterExpress/Models/DuplicatesFormModel.cs
+++ b/src/SorterExpress/Models/DuplicatesFormModel.cs
@@ -78,16 +78,18 @@ namespace SorterExpress.Models
 
         public bool StateSorting { get { return State == FormState.Sorting; } }
 
+        public bool StateViewingDuplicates => Duplicates.Count > 0;
+
         private string directory;
-        public string Directory { get { return directory; } set { directory = value; /*NotifyPropertyChanged();*/ UpdateVisibilityAndEnabledProperties(); } }
+        public string Directory { get { return directory; } set { directory = value; UpdateVisibilityAndEnabledProperties(); } }
 
         public Stack<DuplicateAction> DoneActions { get; set; } = new Stack<DuplicateAction>();
 
-        public bool EnableUndoButton { get { return DoneActions.Count > 0; } }//{ get { return DoneActions != null ? DoneActions.Count > 0 : false; } }
+        public bool EnableUndoButton { get { return DoneActions.Count > 0; } }
 
         public Stack<DuplicateAction> UndoneActions { get; set; } = new Stack<DuplicateAction>();
 
-        public bool EnableRedoButton { get { return UndoneActions.Count > 0; } }//{ get { return UndoneActions != null ? UndoneActions.Count > 0 : false; } }
+        public bool EnableRedoButton { get { return UndoneActions.Count > 0; } }
 
         private bool searching = false;
 
@@ -95,7 +97,6 @@ namespace SorterExpress.Models
 
         public List<string> Files = new List<string>();
 
-        //public SortableBindingList<Duplicate> Duplicates { get; set; } = new SortableBindingList<Duplicate>();
         public BindingList<Duplicate> Duplicates { get; set; } = new BindingList<Duplicate>();
 
         public enum SearchScope
@@ -157,6 +158,7 @@ namespace SorterExpress.Models
         private void Duplicates_ListChanged(object sender, ListChangedEventArgs e)
         {
             Console.WriteLine($"Duplicates_ListChanged: Count: {Duplicates?.Count ?? 0}");
+            NotifyPropertyChanged(nameof(StateViewingDuplicates));
             NotifyPropertyChanged(nameof(FileAndMatchesCountText));
         }
     }

--- a/src/SorterExpress/Models/DuplicatesFormModel.cs
+++ b/src/SorterExpress/Models/DuplicatesFormModel.cs
@@ -113,7 +113,7 @@ namespace SorterExpress.Models
         private bool onlyMatchSameFileTypes = Settings.Default.DuplicateSearch.OnlyMatchSameFileTypes;
         private bool cropLeftAndRight = Settings.Default.DuplicateSearch.CropLeftRightSides;
         private bool cropTopAndBottom = Settings.Default.DuplicateSearch.CropTopBottomSides;
-        private int threadCount = Settings.Default.DuplicateSearch.SearchThreadCount < 1 ? Environment.ProcessorCount : Settings.Default.DuplicateSearch.SearchThreadCount;
+        private int threadCount = Settings.Default.DuplicateSearch.SearchThreadCount == 0 ? Environment.ProcessorCount : Settings.Default.DuplicateSearch.SearchThreadCount;
         private int similarity = Settings.Default.DuplicateSearch.SearchSimilarityPercentage;
         private bool mergeFileTags = Settings.Default.DuplicateSearch.MergeFileTags;
         private bool onlyKeepTagsThatAreInLibrary = Settings.Default.DuplicateSearch.OnlyKeepTagsInLibrary;


### PR DESCRIPTION
The intended behaviour of the duplicate searcher is that the user can perform sorting while searching is still in progress. It was possible to switch between and view found duplicates but all sorting buttons were disabled due to being bound to a property with an incorrect check. This PR creates a new property to bind to and binds all relevant controls `.Enabled` to that property.